### PR TITLE
feat: added option for completing flexible update manually

### DIFF
--- a/android/src/main/kotlin/com/tranglequynh/flutter_upgrade_version/InAppUpdateHandler.kt
+++ b/android/src/main/kotlin/com/tranglequynh/flutter_upgrade_version/InAppUpdateHandler.kt
@@ -23,6 +23,8 @@ class InAppUpdateHandler : MethodChannel.MethodCallHandler, PluginRegistry.Activ
 
   private var pendingResult: MethodChannel.Result? = null
 
+  private var completeOnDownload: Boolean = true
+
   constructor(activity: Activity, binaryMessenger: BinaryMessenger) {
     this.activity = activity
     this.binaryMessenger = binaryMessenger
@@ -59,6 +61,7 @@ class InAppUpdateHandler : MethodChannel.MethodCallHandler, PluginRegistry.Activ
     when (call.method) {
       "checkForUpdate" -> checkForUpdate(result)
       "startAnUpdate" -> startAnUpdate(call, result)
+      "completeUpdate" -> completeUpdate(result)
       else -> result.notImplemented()
     }
   }
@@ -93,7 +96,7 @@ class InAppUpdateHandler : MethodChannel.MethodCallHandler, PluginRegistry.Activ
   }
 
   /// After you confirm that an update is available, you can request an update using
-  private fun startAnUpdate(call: MethodCall, result: MethodChannel.Result) {
+  private fun startAnUpdate(call: MethodCall, result: MethodChannel.Result) { 
     @Suppress("UNCHECKED_CAST")
     val args = call.arguments as Map<String, Any>
     val type = when(args["appUpdateType"]) {
@@ -101,6 +104,9 @@ class InAppUpdateHandler : MethodChannel.MethodCallHandler, PluginRegistry.Activ
       1 -> AppUpdateType.IMMEDIATE
       else -> null
     }
+
+    completeOnDownload = args["completeOnDownload"] as? Boolean ?: true
+
     requireNotNull(type) {
       result.error("ERROR", "MSG_APP_UPDATE_TYPE_NO_SUPPORT", null)
     }
@@ -130,6 +136,22 @@ class InAppUpdateHandler : MethodChannel.MethodCallHandler, PluginRegistry.Activ
     )
   }
 
+  private fun completeUpdate(result: MethodChannel.Result) {
+    if (appUpdateManager == null) {
+      result.error("ERROR", "MSG_APP_UPDATE_MANAGER_NOT_INITIALIZED", null)
+      return
+    }
+    
+    appUpdateManager!!.completeUpdate()
+      .addOnSuccessListener {
+        result.success(null)
+        // App will restart here automatically
+      }
+      .addOnFailureListener { error ->
+        result.error("ERROR", "MSG_COMPLETE_UPDATE_FAILED", error.message)
+      }
+  }
+
   private fun unregisterUpdate() {
     // When status updates are no longer needed, unregister the listener.
     appUpdateManager?.unregisterListener(updateListener)
@@ -141,7 +163,13 @@ class InAppUpdateHandler : MethodChannel.MethodCallHandler, PluginRegistry.Activ
       // and request user confirmation to restart the app.
       pendingResult?.success(null)
       pendingResult = null
-      appUpdateManager?.completeUpdate()
+      if (completeOnDownload) {
+        appUpdateManager?.completeUpdate()
+      } else {
+        activity.runOnUiThread {
+          inAppUpdateChannel.invokeMethod("onUpdateDownloaded", null)
+        }
+      }
       unregisterUpdate()
     } else if (it.installErrorCode() != InstallErrorCode.NO_ERROR) {
       pendingResult?.error("ERROR", "MSG_UPDATE_LISTENER_ERROR", null)

--- a/lib/platforms/in_app_update_platform.dart
+++ b/lib/platforms/in_app_update_platform.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import '../models/app_update_info.dart';
 
 /// The interface that implementations of in-app-update must implement
@@ -15,5 +16,17 @@ abstract class InAppUpdatePlatform {
 
   /// After you confirm that an update is available, you can request an update
   /// Android support: Flexible updates and Immediate updates
-  Future<String?> startAnUpdate({AppUpdateType type = AppUpdateType.flexible});
+  /// [completeOnDownload] - if true, automatically completes update when downloaded (default: true)
+  /// if false, you must manually call completeUpdate() to restart the app
+  /// [onUpdateDownloaded] - callback triggered when update finishes downloading (only if completeOnDownload = false)
+
+  Future<String?> startAnUpdate({
+    AppUpdateType type = AppUpdateType.flexible,
+    bool completeOnDownload = true,
+    VoidCallback? onUpdateDownloaded,
+  });
+
+  /// Manually complete a flexible update after download
+  /// Only needed when startAnUpdate was called with completeOnDownload = false
+  Future<String?> completeUpdate();
 }

--- a/lib/src/in_app_update_manager.dart
+++ b/lib/src/in_app_update_manager.dart
@@ -10,6 +10,24 @@ class InAppUpdateManager implements InAppUpdatePlatform {
   static const MethodChannel _channel =
       MethodChannel('com.tranglequynh.flutter-upgrade-version/in-app-update');
 
+  VoidCallback? _onUpdateDownloadedCallback;
+
+  InAppUpdateManager() {
+    // Set up listener for events from Kotlin
+    _channel.setMethodCallHandler(_handleMethodCall);
+  }
+
+  Future<dynamic> _handleMethodCall(MethodCall call) async {
+    switch (call.method) {
+      case 'onUpdateDownloaded':
+        _onUpdateDownloadedCallback?.call();
+        _onUpdateDownloadedCallback = null;
+        break;
+      default:
+        throw MissingPluginException('Unknown method: ${call.method}');
+    }
+  }
+
   /// checkForUpdate
   /// Return AppUpdateInfo
   @override
@@ -27,10 +45,31 @@ class InAppUpdateManager implements InAppUpdatePlatform {
   /// startAnUpdate
   @override
   Future<String?> startAnUpdate(
-      {AppUpdateType type = AppUpdateType.flexible}) async {
+      {AppUpdateType type = AppUpdateType.flexible,
+      bool completeOnDownload = true,
+      VoidCallback? onUpdateDownloaded}) async {
     try {
-      await _channel
-          .invokeMethod('startAnUpdate', {'appUpdateType': type.index});
+      if (!completeOnDownload) {
+        _onUpdateDownloadedCallback = onUpdateDownloaded;
+      }
+      await _channel.invokeMethod('startAnUpdate', {
+        'appUpdateType': type.index,
+        'completeOnDownload': completeOnDownload
+      });
+      return null;
+    } on PlatformException catch (e) {
+      _onUpdateDownloadedCallback = null;
+      return e.message;
+    } on Exception catch (e) {
+      _onUpdateDownloadedCallback = null;
+      return 'Exception: ${e.toString()}';
+    }
+  }
+
+  @override
+  Future<String?> completeUpdate() async {
+    try {
+      await _channel.invokeMethod('completeUpdate');
       return null;
     } on PlatformException catch (e) {
       return e.message;


### PR DESCRIPTION
## Summary
Adds an optional `completeOnDownload` parameter to `startAnUpdate()` to give developers control over when the app restarts after a flexible update downloads.

## Changes
- Added `completeOnDownload` parameter (default: `true`) to `startAnUpdate()`
- Added `completeUpdate()` method to manually trigger app restart
- Modified Kotlin `InAppUpdateHandler` to send `onUpdateDownloaded` event to Flutter when `completeOnDownload` is `false`
- Updated `InAppUpdateManager` to handle method channel callbacks

## Motivation
Currently, flexible updates automatically restart the app immediately after download completes. This doesn't allow developers to:
- Show a custom snackbar/dialog to the user
- Let users choose when to restart
- Provide a better UX around app updates

## Usage Example

### Before (auto-restart):
```dart
await InAppUpdate.startAnUpdate(type: AppUpdateType.flexible);
// App restarts immediately after download
```

### After (manual control):
```dart
await InAppUpdate.startAnUpdate(
  type: AppUpdateType.flexible,
  completeOnDownload: false,
  onUpdateDownloaded: () {
    // Show custom snackbar
    ScaffoldMessenger.of(context).showSnackBar(
      SnackBar(
        content: Text("Update ready!"),
        action: SnackBarAction(
          label: "Restart",
          onPressed: () => InAppUpdate.completeUpdate(),
        ),
      ),
    );
  },
);
```

## Backward Compatibility
✅ Fully backward compatible - default behavior unchanged (`completeOnDownload: true`)

## Testing
- [x] Tested with `completeOnDownload: true` (auto-restart works)
- [x] Tested with `completeOnDownload: false` (callback triggered, manual restart works)
- [x] Tested on Android release build via Internal Testing track

## Checklist
- [x] Code follows project style guidelines
- [x] Changes are backward compatible
- [x] Tested on real device
- [ ] Documentation updated (if needed)